### PR TITLE
html2hscript should output style attribute as an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,17 @@ module.exports = function(html, cb) {
             var classNames = attribs['class'];
             var classSuffix = (classNames !== undefined ? classNames : '').split(/\s+/g).filter(function (v) { return v.length > 0; }).map(function (cls) { return '.' + cls; }).join('');
             delete attribs['class'];
+            // Convert inline CSS style attribute to an object
+            if(attribs['style']){
+                var rules = attribs["style"].split(";");
+                attribs["style"] = {};
+                rules.forEach(function(rule){
+                    var split = rule.split(":");
+                    if(split.length == 2){
+                        attribs["style"][split[0].trim()] = split[1].trim();
+                    }
+                });
+            }            
 
             var attrPairs = Object.keys(attribs).map(function (k) { return JSON.stringify(k) + ': ' + JSON.stringify(attribs[k]) });
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "htmlparser2": "^3.8.2"
   },
   "devDependencies": {
-    "tap": "^0.7.1"
+    "tap": "^1.3.1"
   },
   "scripts": {
     "test": "tap test/*.js"

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -28,3 +28,10 @@ test('should handle correctly pre', function(t) {
     t.end()
   })
 })
+
+test('should output style attribute as an object', function(t) {
+  parser('<h1 style="color: red; font-size: 12px">Hello World</h1>', function(err, hscript) {
+    t.equals(hscript, 'h("h1", { "style": {"color":"red","font-size":"12px"} }, [ "Hello World" ])', 'success')
+    t.end()
+  })
+})


### PR DESCRIPTION
This fixes an issue where html2hscript  generates a string for style attributes instead an object that's expected by virtual-dom hscript
