### PR TITLE
Force 'value' to be a property, not an attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,6 +128,10 @@ module.exports = function(html, cb) {
             } );
 
             var objects = {}
+            if (attribs.value) {
+                objects.value = attribs.value;
+                delete attribs.value;
+            }
             if ( !isEmpty( style ) ) objects.style = style
             if ( !isEmpty( attribs ) ) objects.attributes = attribs
             if ( !isEmpty( dataset ) ) objects.dataset = dataset


### PR DESCRIPTION
@twilson63: I ran into a problem using this library when generating and applying patches using `virtual-dom`.

The problem was that I would change the value of an `<input>` element in the HTML string and pass it through html2hscript and send the resulting hscript to `virtual-dom` to generate and apply a patch, but the  browser didn't show the change. This is because the `value` attribute just sets the `initialValue`, you have to set `value` as a property in order to see the change in the browser (see [this](http://stackoverflow.com/a/29929977/194758) and [this](https://bugzilla.mozilla.org/show_bug.cgi?id=27327#c23)).

VirtualDOM has a writeup [here](https://github.com/Matt-Esch/virtual-dom/blob/master/docs/vnode.md) about `value` vs `defaultValue` vs `attributes.value`, along with some other similar problems.

This pull request fixed my problem by always treating `value` as a property instead of an attribute, but I'm not 100% certain that's the behavior everyone will expect -- someone may actually want it to be the attribute/defaultValue, but that behavior doesn't seem as useful to me.

Anyways, this seems like a bit of a hack, but it was the only way I could think of to support my use-case (using html2hscript to connect a string-based templating stack with `virtual-dom`).
