### PR TITLE
Add HTML entity conversion

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 // code pulled from https://www.npmjs.com/package/html2hyperscript
 var Parser = require('htmlparser2').Parser;
 var camel = require('to-camel-case');
+var ent = require('ent');
 var isEmpty = require('is-empty');
 var thisIsSVGTag = require('./lib/svg-namespaces').thisIsSVGTag,
     getSVGNamespace = require('./lib/svg-namespaces').getSVGNamespace,
@@ -52,7 +53,7 @@ module.exports = function(html, cb) {
             elementStack.unshift([ name, attribs ]);
         },
         ontext: function (text) {
-            currentItemList.add(JSON.stringify(text));
+            currentItemList.add(JSON.stringify(ent.decode(text)));
             /*var lines = text.split("\n");
 
              var isFirst = true;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "ent": "^2.2.0",
     "htmlparser2": "^3.8.2",
     "is-empty": "0.0.1",
     "to-camel-case": "^0.2.1"


### PR DESCRIPTION
Add a dependency on [node-ent](https://github.com/substack/node-ent) to encode HTML entities. This is expected approach to [HTML entities with Virtual-DOM](https://github.com/Matt-Esch/virtual-dom/issues/103).
